### PR TITLE
Fix Dockerfile license labels

### DIFF
--- a/.development/build/Dockerfile
+++ b/.development/build/Dockerfile
@@ -1,3 +1,6 @@
+# License: apache-2.0
+LABEL org.opencontainers.image.licenses="apache-2.0"
+
 FROM golang:1.26-alpine
 RUN apk add bash git && \
     mkdir -p /opt &&  \

--- a/.development/docs/Dockerfile
+++ b/.development/docs/Dockerfile
@@ -1,3 +1,6 @@
+# License: apache-2.0
+LABEL org.opencontainers.image.licenses="apache-2.0"
+
 FROM alpine:3
 RUN apk add git bash make gawk
 RUN mkdir -p /workspace &&  \


### PR DESCRIPTION

            This PR fixes the `org.opencontainers.image.licenses` labels in Dockerfiles to match the repository license (apache-2.0).
            
            Changes made:
            - ✅ Addd license label in `Dockerfile`
- ✅ Addd license label in `Dockerfile`

Repository license: `apache-2.0`